### PR TITLE
Allow entrypoints.json to be hosted remotely

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -117,14 +117,15 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
             }
         }
 
-        if (!file_exists($this->entrypointJsonPath)) {
+        $entrypointJsonContents = file_get_contents($this->entrypointJsonPath);
+        if ($entrypointJsonContents === false) {
             if (!$this->strictMode) {
                 return [];
             }
-            throw new \InvalidArgumentException(sprintf('Could not find the entrypoints file from Webpack: the file "%s" does not exist.', $this->entrypointJsonPath));
+            throw new \InvalidArgumentException(sprintf('Could not find the entrypoints file from Webpack: the file "%s" does not exist or it is not readable.', $this->entrypointJsonPath));
         }
 
-        $this->entriesData = json_decode(file_get_contents($this->entrypointJsonPath), true);
+        $this->entriesData = json_decode($entrypointJsonContents, true);
 
         if (null === $this->entriesData) {
             throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file', $this->entrypointJsonPath));


### PR DESCRIPTION
- When the assets Webpack Encore builds are not hosted on a Docker container's filesystem but published remotely (on a Google Cloud Storage bucket for example), file_exists on entrypoints.json fails.
- When strict_mode is true, an exception is raised and it's imposible to load the assets.
- Just after this check and condition, a file_get_contents is used to retrieve the entrypoints.json contents.

What I'm proposing is to use file_get_contents earlier to allow fetching a remote entrypoints.json to solve the CDN use case. 